### PR TITLE
Proxy Overhaul 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["eslint:recommended"],
+  "env": {
+    "amd": true,
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2017
+  }
+}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: borales/actions-yarn@v2.0.0
+      with:
+        cmd: install
+    #- uses: borales/actions-yarn@v2.0.0
+    #  with:
+    #      cmd: build
+    - uses: borales/actions-yarn@v2.0.0
+      with:
+          cmd: lint
+    - uses: borales/actions-yarn@v2.0.0
+      with:
+          cmd: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,5 @@
 name: Node.js CI
-
 on: [push]
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +19,9 @@ jobs:
     - uses: borales/actions-yarn@v2.0.0
       with:
           cmd: lint
+    - uses: borales/actions-yarn@v2.0.0
+      with:
+          cmd: format-check
     - uses: borales/actions-yarn@v2.0.0
       with:
           cmd: test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # A dynamic configurable reverse proxy for use within Galaxy
 
+To double-proxy (e.g. from Galaxy to a remote proxy that proxies to the application):
+
+```console
+host1$ ./lib/main.js --sessions test.sqlite --forwardIP host2 --forwardPort 8001
+host2$ ./lib/main.js --port 8001
+```

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,9 @@ args
     .option('--ip <n>', 'Public-facing IP of the proxy', 'localhost')
     .option('--port <n>', 'Public-facing port of the proxy', parseInt)
     .option('--sessions <file>', 'Routes file to monitor')
-    .option('--cookie <str>', 'IGNORED')
+    .option('--forwardIP <n>', 'Forward all requests to IP')
+    .option('--forwardPort <n>', 'Forward all requests to port', parseInt)
+    .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
     .option('--verbose')
 
 args.parse(process.argv);
@@ -21,7 +23,10 @@ args.parse(process.argv);
 var DynamicProxy = require('./proxy.js').DynamicProxy;
 var mapFor = require('./mapper.js').mapFor;
 
-var sessions = mapFor(args.sessions);
+var sessions = null;
+if(args.sessions) {
+    sessions = mapFor(args.sessions);
+}
 
 var dynamic_proxy_options = {
   sessionMap: sessions,
@@ -29,9 +34,17 @@ var dynamic_proxy_options = {
   port: args['port']
 }
 
-//if(args.reverseProxy){
- //   dynamic_proxy_options.reverseProxy = true;
-//}
+if(args.reverseProxy){
+    dynamic_proxy_options.reverseProxy = true;
+}
+
+if(args.forwardIP){
+    dynamic_proxy_options.forwardIP = args['forwardIP']
+}
+
+if(args.forwardPort){
+    dynamic_proxy_options.forwardPort = args['forwardPort']
+}
 
 var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,10 +3,8 @@
 Inspiration taken from
 	https://github.com/jupyter/multiuser-server/blob/master/multiuser/js/main.js
 */
-var fs = require("fs");
 var args = require("commander");
-
-package_info = require("../package");
+var package_info = require("../package");
 
 args
   .version(package_info)
@@ -21,9 +19,9 @@ args
   )
   .option("--verbose");
 
-var main = function(argv) {
-  argv = argv || process.argv;
-  args.parse(process.argv);
+var main = function(argv_) {
+  var argv = argv_ || process.argv;
+  args.parse(argv);
 
   var DynamicProxy = require("./proxy.js").DynamicProxy;
   var mapFor = require("./mapper.js").mapFor;

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,43 +16,51 @@ args
     .option('--forwardIP <n>', 'Forward all requests to IP')
     .option('--forwardPort <n>', 'Forward all requests to port', parseInt)
     .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
-    .option('--verbose')
+    .option('--verbose');
 
-args.parse(process.argv);
 
-var DynamicProxy = require('./proxy.js').DynamicProxy;
-var mapFor = require('./mapper.js').mapFor;
+var main = function(argv) {
+    argv = argv || process.argv;
+    args.parse(process.argv);
 
-var sessions = null;
-if(args.sessions) {
-    sessions = mapFor(args.sessions);
+    var DynamicProxy = require('./proxy.js').DynamicProxy;
+    var mapFor = require('./mapper.js').mapFor;
+   
+    var sessions = null;
+    if(args.sessions) {
+         sessions = mapFor(args.sessions);
+    }
+
+    var dynamic_proxy_options = {
+       sessionMap: sessions,
+       verbose: args.verbose,
+       port: args['port']
+    }
+
+    if(args.reverseProxy){
+         dynamic_proxy_options.reverseProxy = true;
+    }
+
+    if(args.forwardIP){
+         dynamic_proxy_options.forwardIP = args['forwardIP']
+    }
+
+    if(args.forwardPort){
+        dynamic_proxy_options.forwardPort = args['forwardPort']
+    }
+
+    var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
+
+    var listen = {};
+    listen.port = args.port || 8000;
+    listen.ip = args.ip;
+
+    if(args.verbose) {
+	       console.log("Listening on " + listen.ip + ":" + listen.port);
+    }
+    dynamic_proxy.proxy_server.listen(listen.port, listen.ip);
 }
 
-var dynamic_proxy_options = {
-  sessionMap: sessions,
-  verbose: args.verbose,
-  port: args['port']
+if (require.main === module) {
+    main();
 }
-
-if(args.reverseProxy){
-    dynamic_proxy_options.reverseProxy = true;
-}
-
-if(args.forwardIP){
-    dynamic_proxy_options.forwardIP = args['forwardIP']
-}
-
-if(args.forwardPort){
-    dynamic_proxy_options.forwardPort = args['forwardPort']
-}
-
-var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
-
-var listen = {};
-listen.port = args.port || 8000;
-listen.ip = args.ip;
-
-if(args.verbose) {
-	console.log("Listening on " + listen.ip + ":" + listen.port);
-}
-dynamic_proxy.proxy_server.listen(listen.port, listen.ip);

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ const { DynamicProxy } = require("./proxy");
 const { mapFor } = require("./mapper");
 
 args
-  .version(packageInfo)
+  .version(packageInfo.version)
   .option("--ip <n>", "Public-facing IP of the proxy", "localhost")
   .option("--port <n>", "Public-facing port of the proxy", parseInt)
   .option("--sessions <file>", "Routes file to monitor")

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,9 +12,8 @@ args
 	.version(package_info)
     .option('--ip <n>', 'Public-facing IP of the proxy', 'localhost')
     .option('--port <n>', 'Public-facing port of the proxy', parseInt)
-    .option('--cookie <cookiename>', 'Cookie proving authentication', 'galaxysession')
     .option('--sessions <file>', 'Routes file to monitor')
-    .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
+    .option('--cookie <str>', 'IGNORED')
     .option('--verbose')
 
 args.parse(process.argv);
@@ -25,15 +24,14 @@ var mapFor = require('./mapper.js').mapFor;
 var sessions = mapFor(args.sessions);
 
 var dynamic_proxy_options = {
-  sessionCookie: args['cookie'],
   sessionMap: sessions,
   verbose: args.verbose,
   port: args['port']
 }
 
-if(args.reverseProxy){
-    dynamic_proxy_options.reverseProxy = true;
-}
+//if(args.reverseProxy){
+ //   dynamic_proxy_options.reverseProxy = true;
+//}
 
 var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,11 +54,7 @@ var main = function(argv) {
     var listen = {};
     listen.port = args.port || 8000;
     listen.ip = args.ip;
-
-    if(args.verbose) {
-	       console.log("Listening on " + listen.ip + ":" + listen.port);
-    }
-    dynamic_proxy.proxy_server.listen(listen.port, listen.ip);
+    dynamic_proxy.listen(listen);
 }
 
 if (require.main === module) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,60 +3,62 @@
 Inspiration taken from
 	https://github.com/jupyter/multiuser-server/blob/master/multiuser/js/main.js
 */
-var fs = require('fs');
-var args = require('commander');
+var fs = require("fs");
+var args = require("commander");
 
-package_info = require('../package')
+package_info = require("../package");
 
 args
-	.version(package_info)
-    .option('--ip <n>', 'Public-facing IP of the proxy', 'localhost')
-    .option('--port <n>', 'Public-facing port of the proxy', parseInt)
-    .option('--sessions <file>', 'Routes file to monitor')
-    .option('--forwardIP <n>', 'Forward all requests to IP')
-    .option('--forwardPort <n>', 'Forward all requests to port', parseInt)
-    .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
-    .option('--verbose');
-
+  .version(package_info)
+  .option("--ip <n>", "Public-facing IP of the proxy", "localhost")
+  .option("--port <n>", "Public-facing port of the proxy", parseInt)
+  .option("--sessions <file>", "Routes file to monitor")
+  .option("--forwardIP <n>", "Forward all requests to IP")
+  .option("--forwardPort <n>", "Forward all requests to port", parseInt)
+  .option(
+    "--reverseProxy",
+    "Cause the proxy to rewrite location blocks with its own port"
+  )
+  .option("--verbose");
 
 var main = function(argv) {
-    argv = argv || process.argv;
-    args.parse(process.argv);
+  argv = argv || process.argv;
+  args.parse(process.argv);
 
-    var DynamicProxy = require('./proxy.js').DynamicProxy;
-    var mapFor = require('./mapper.js').mapFor;
-   
-    var sessions = null;
-    if(args.sessions) {
-         sessions = mapFor(args.sessions);
-    }
+  var DynamicProxy = require("./proxy.js").DynamicProxy;
+  var mapFor = require("./mapper.js").mapFor;
 
-    var dynamic_proxy_options = {
-       sessionMap: sessions,
-       verbose: args.verbose,
-       port: args['port']
-    }
+  var sessions = null;
+  if (args.sessions) {
+    sessions = mapFor(args.sessions);
+  }
 
-    if(args.reverseProxy){
-         dynamic_proxy_options.reverseProxy = true;
-    }
+  var dynamic_proxy_options = {
+    sessionMap: sessions,
+    verbose: args.verbose,
+    port: args["port"]
+  };
 
-    if(args.forwardIP){
-         dynamic_proxy_options.forwardIP = args['forwardIP']
-    }
+  if (args.reverseProxy) {
+    dynamic_proxy_options.reverseProxy = true;
+  }
 
-    if(args.forwardPort){
-        dynamic_proxy_options.forwardPort = args['forwardPort']
-    }
+  if (args.forwardIP) {
+    dynamic_proxy_options.forwardIP = args["forwardIP"];
+  }
 
-    var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
+  if (args.forwardPort) {
+    dynamic_proxy_options.forwardPort = args["forwardPort"];
+  }
 
-    var listen = {};
-    listen.port = args.port || 8000;
-    listen.ip = args.ip;
-    dynamic_proxy.listen(listen);
-}
+  var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
+
+  var listen = {};
+  listen.port = args.port || 8000;
+  listen.ip = args.ip;
+  dynamic_proxy.listen(listen);
+};
 
 if (require.main === module) {
-    main();
+  main();
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,11 +4,12 @@ Inspiration taken from
 	https://github.com/jupyter/multiuser-server/blob/master/multiuser/js/main.js
 */
 const args = require("commander");
-const package_info = require("../package");
+const packageInfo = require("../package");
 const { DynamicProxy } = require("./proxy");
+const { mapFor } = require("./mapper");
 
 args
-  .version(package_info)
+  .version(packageInfo)
   .option("--ip <n>", "Public-facing IP of the proxy", "localhost")
   .option("--port <n>", "Public-facing port of the proxy", parseInt)
   .option("--sessions <file>", "Routes file to monitor")
@@ -20,41 +21,40 @@ args
   )
   .option("--verbose");
 
-var main = function(argv_) {
-  var argv = argv_ || process.argv;
+const main = function(argv_) {
+  const argv = argv_ || process.argv;
   args.parse(argv);
 
-  var sessions = null;
+  let sessions = null;
   if (args.sessions) {
-    var mapFor = require("./mapper.js").mapFor;
     sessions = mapFor(args.sessions);
   }
 
-  var dynamic_proxy_options = {
+  const dynamicProxyOptions = {
     sessionMap: sessions,
     verbose: args.verbose,
     port: args.port
   };
 
   if (args.reverseProxy) {
-    dynamic_proxy_options.reverseProxy = true;
+    dynamicProxyOptions.reverseProxy = true;
   }
 
   if (args.forwardIP) {
-    dynamic_proxy_options.forwardIP = args["forwardIP"];
+    dynamicProxyOptions.forwardIP = args["forwardIP"];
   }
 
   if (args.forwardPort) {
-    dynamic_proxy_options.forwardPort = args["forwardPort"];
+    dynamicProxyOptions.forwardPort = args["forwardPort"];
   }
 
-  var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
-
-  var listen = {};
-  listen.port = args.port || 8000;
-  listen.ip = args.ip;
-  dynamic_proxy.listen(listen);
-  return dynamic_proxy;
+  const dynamicProxy = new DynamicProxy(dynamicProxyOptions);
+  const listen = {
+    port: args.port || 8000,
+    ip: args.ip
+  };
+  dynamicProxy.listen(listen);
+  return dynamicProxy;
 };
 
 exports.main = main;

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,8 +3,9 @@
 Inspiration taken from
 	https://github.com/jupyter/multiuser-server/blob/master/multiuser/js/main.js
 */
-var args = require("commander");
-var package_info = require("../package");
+const args = require("commander");
+const package_info = require("../package");
+const { DynamicProxy } = require("./proxy");
 
 args
   .version(package_info)
@@ -23,18 +24,16 @@ var main = function(argv_) {
   var argv = argv_ || process.argv;
   args.parse(argv);
 
-  var DynamicProxy = require("./proxy.js").DynamicProxy;
-  var mapFor = require("./mapper.js").mapFor;
-
   var sessions = null;
   if (args.sessions) {
+    var mapFor = require("./mapper.js").mapFor;
     sessions = mapFor(args.sessions);
   }
 
   var dynamic_proxy_options = {
     sessionMap: sessions,
     verbose: args.verbose,
-    port: args["port"]
+    port: args.port
   };
 
   if (args.reverseProxy) {
@@ -55,7 +54,10 @@ var main = function(argv_) {
   listen.port = args.port || 8000;
   listen.ip = args.ip;
   dynamic_proxy.listen(listen);
+  return dynamic_proxy;
 };
+
+exports.main = main;
 
 if (require.main === module) {
   main();

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -1,32 +1,35 @@
-var fs = require('fs');
-var sqlite3 = require('sqlite3')
-var watch = require('node-watch');
-
+var fs = require("fs");
+var sqlite3 = require("sqlite3");
+var watch = require("node-watch");
 
 var endsWith = function(subjectString, searchString) {
-    var position = subjectString.length;
-    position -= searchString.length;
-    var lastIndex = subjectString.indexOf(searchString, position);
-    return lastIndex !== -1 && lastIndex === position;
+  var position = subjectString.length;
+  position -= searchString.length;
+  var lastIndex = subjectString.indexOf(searchString, position);
+  return lastIndex !== -1 && lastIndex === position;
 };
 
-
 var updateFromJson = function(path, map) {
-    var content = fs.readFileSync(path, 'utf8');
-    var keyToSession = JSON.parse(content);
-    var newSessions = {};
-    for(var key in keyToSession) {
-        newSessions[key] = {'target': {'host': keyToSession[key]['host'], 'port': parseInt(keyToSession[key]['port'])}};
+  var content = fs.readFileSync(path, "utf8");
+  var keyToSession = JSON.parse(content);
+  var newSessions = {};
+  for (var key in keyToSession) {
+    newSessions[key] = {
+      target: {
+        host: keyToSession[key]["host"],
+        port: parseInt(keyToSession[key]["port"])
+      }
+    };
+  }
+  for (var oldSession in map) {
+    if (!(oldSession in newSessions)) {
+      delete map[oldSession];
     }
-    for(var oldSession in map) {
-        if(!(oldSession in newSessions)) {
-            delete map[ oldSession ];
-        }
-    }
-    for(var newSession in newSessions) {
-        map[newSession] = newSessions[newSession];
-    }
-}
+  }
+  for (var newSession in newSessions) {
+    map[newSession] = newSessions[newSession];
+  }
+};
 /*
 CREATE TABLE gxitproxy
                                  (key text,
@@ -43,50 +46,53 @@ INSERT INTO "gxitproxy" VALUES('d24902ddec2e97f1','interactivetoolentrypoint','b
 */
 
 var updateFromSqlite = function(path, map) {
-    var newSessions = {};
-    var loadSessions = function() {
-        db.each("SELECT key, key_type, token, host, port FROM gxitproxy", function(err, row) {
-            var key = row['key'];
-            newSessions[key] = {
-	    	'target': {'host': row['host'], 'port': parseInt(row['port'])},
-		'key_type': row['key_type'],
-		'token': row['token'],
-	    };
-        }, finish);
-    };
+  var newSessions = {};
+  var loadSessions = function() {
+    db.each(
+      "SELECT key, key_type, token, host, port FROM gxitproxy",
+      function(err, row) {
+        var key = row["key"];
+        newSessions[key] = {
+          target: { host: row["host"], port: parseInt(row["port"]) },
+          key_type: row["key_type"],
+          token: row["token"]
+        };
+      },
+      finish
+    );
+  };
 
-    var finish = function() {
-        for(var oldSession in map) {
-            if(!(oldSession in newSessions)) {
-                delete map[ oldSession ];
-            }
-        }
-        for(var newSession in newSessions) {
-            map[newSession] = newSessions[newSession];
-        }
-        db.close();
-    };
+  var finish = function() {
+    for (var oldSession in map) {
+      if (!(oldSession in newSessions)) {
+        delete map[oldSession];
+      }
+    }
+    for (var newSession in newSessions) {
+      map[newSession] = newSessions[newSession];
+    }
+    db.close();
+  };
 
-    var db = new sqlite3.Database(path, loadSessions);
+  var db = new sqlite3.Database(path, loadSessions);
 };
 
-
 var mapFor = function(path) {
-    var map = {};
-    var loadMap;
-    if(endsWith(path, '.sqlite')) {
-        loadMap = function() {
-            updateFromSqlite(path, map);
-        }
-    } else {
-        loadMap = function() {
-            updateFromJson(path, map);
-        }
-    }
-    console.log("Watching path " + path);
-    loadMap();
-    watch(path, loadMap);
-    return map;
+  var map = {};
+  var loadMap;
+  if (endsWith(path, ".sqlite")) {
+    loadMap = function() {
+      updateFromSqlite(path, map);
+    };
+  } else {
+    loadMap = function() {
+      updateFromJson(path, map);
+    };
+  }
+  console.log("Watching path " + path);
+  loadMap();
+  watch(path, loadMap);
+  return map;
 };
 
 exports.mapFor = mapFor;

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -47,7 +47,6 @@ var updateFromSqlite = function(path, map) {
     var loadSessions = function() {
         db.each("SELECT key, key_type, token, host, port FROM gxitproxy", function(err, row) {
             var key = row['key'];
-            console.log(key);
             newSessions[key] = {
 	    	'target': {'host': row['host'], 'port': parseInt(row['port'])},
 		'key_type': row['key_type'],
@@ -65,7 +64,6 @@ var updateFromSqlite = function(path, map) {
         for(var newSession in newSessions) {
             map[newSession] = newSessions[newSession];
         }
- console.log(map);
         db.close();
     };
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -27,14 +27,32 @@ var updateFromJson = function(path, map) {
         map[newSession] = newSessions[newSession];
     }
 }
+/*
+CREATE TABLE gxitproxy
+                                 (key text,
+                                  key_type text,
+                                  token text,
+                                  host text,
+                                  port integer,
+                                  info text,
+                                  PRIMARY KEY (key, key_type)
+                                  );
+INSERT INTO "gxitproxy" VALUES('e3c1915314cbd610','interactivetoolentrypoint','d76ec842e77049059753b0d40992d15f','132.230.68.22',1033,NULL);
+INSERT INTO "gxitproxy" VALUES('d24902ddec2e97f1','interactivetoolentrypoint','bea3a5bb3d4b4c6c8bcb7579e023bf66','132.230.68.22',1035,NULL);
+
+*/
 
 var updateFromSqlite = function(path, map) {
     var newSessions = {};
     var loadSessions = function() {
-        db.each("SELECT key, host, port FROM gxproxy2", function(err, row) {
+        db.each("SELECT key, key_type, token, host, port FROM gxitproxy", function(err, row) {
             var key = row['key'];
-            var target = {'host': row['host'], 'port': parseInt(row['port'])};
-            newSessions[key] = {'target': target};
+            console.log(key);
+            newSessions[key] = {
+	    	'target': {'host': row['host'], 'port': parseInt(row['port'])},
+		'key_type': row['key_type'],
+		'token': row['token'],
+	    };
         }, finish);
     };
 
@@ -47,6 +65,7 @@ var updateFromSqlite = function(path, map) {
         for(var newSession in newSessions) {
             map[newSession] = newSessions[newSession];
         }
+ console.log(map);
         db.close();
     };
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -16,6 +16,8 @@ var DynamicProxy = function(options) {
     this.debug = options.verbose;
     this.reverseProxy = options.reverseProxy;
     this.port = options.port;
+    this.forwardIP = options.forwardIP;
+    this.forwardPort = options.forwardPort;
 
     var log_errors = function(handler) {
         return function (req, res) {
@@ -57,25 +59,58 @@ DynamicProxy.prototype.rewriteRequest = function(request) {
     }
 }
 
+DynamicProxy.prototype.targetFromSessionMap = function(request) {
+    for (var mappedSession in this.sessionMap) {
+        if(key == mappedSession) {
+            if(this.sessionMap[key].token == token){
+                return this.sessionMap[key].target;
+            }
+        }
+    }
+}
+
+DynamicProxy.prototype.targetFromHeaders = function(request) {
+    return {'host': request.headers['x-interactive-tool-host'], 'port': parseInt(request.headers['x-interactive-tool-port'])};
+}
+
 DynamicProxy.prototype.targetForRequest = function(request) {
     // return proxy target for a given url
     req_host = request.headers.host;
     key = req_host.substring(0, req_host.indexOf('-'));
     token = req_host.substring(req_host.indexOf('-') + 1, req_host.indexOf('.'));
 
-    for (var mappedSession in this.sessionMap) {
-        if(key == mappedSession) {
-		if(this.sessionMap[key].token == token){
-            		return this.sessionMap[key].target;
-		}
-        }
+    if(this.sessionMap) {
+        var target = this.targetFromSessionMap(request);
+    } else {
+        var target = this.targetFromHeaders(request);
+    }
+
+    if(target) {
+        return target;
     }
 
     if(this.debug) {
-        console.log("No target found for " + req_host + " " + req.method + " " + req.url)
+        console.log("No target found for " + req_host + " " + request.method + " " + request.url)
     }
     return null;
 };
+
+
+DynamicProxy.prototype.configureForward = function(req, target) {
+    var _target = Object.assign({}, target);
+    // FIXME: else delete header so the proxy can't be controlled
+    if(this.forwardIP) {
+        console.log("Forwarding request for " + target.host + " to " + this.forwardIP);
+        req.headers['x-interactive-tool-host'] = target.host;
+        _target.host = this.forwardIP;
+    }
+    if(this.forwardPort) {
+        console.log("Forwarding request for " + target.port + " to " + this.forwardPort);
+        req.headers['x-interactive-tool-port'] = target.port;
+        _target.port = this.forwardPort;
+    }
+    return _target
+}
 
 DynamicProxy.prototype.handleProxyRequest = function(req, res) {
     var othis = this;
@@ -118,6 +153,7 @@ DynamicProxy.prototype.handleProxyRequest = function(req, res) {
         }
 
     }
+    target = this.configureForward(req, target);
     this.proxy.web(req, res, {
         target: target
     }, function (e) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,7 +1,7 @@
-var http = require("http"),
+const http = require("http"),
   httpProxy = require("http-proxy");
 
-var bound = function(that, method) {
+const bound = function(that, method) {
   // bind a method, to ensure `this=that` when it is called
   // because prototype languages are bad
   return function() {
@@ -9,7 +9,7 @@ var bound = function(that, method) {
   };
 };
 
-var DynamicProxy = function(options) {
+const DynamicProxy = function(options) {
   var dynamicProxy = this;
   this.sessionCookie = options.sessionCookie;
   this.sessionMap = options.sessionMap;
@@ -20,7 +20,7 @@ var DynamicProxy = function(options) {
   this.forwardPort = options.forwardPort;
 
   var log_errors = function(handler) {
-    return function(req, res) {
+    return function(req) {
       try {
         return handler.apply(dynamicProxy, arguments);
       } catch (e) {
@@ -38,9 +38,9 @@ var DynamicProxy = function(options) {
     };
   };
 
-  var proxy = (this.proxy = httpProxy.createProxyServer({
+  this.proxy = httpProxy.createProxyServer({
     ws: true
-  }));
+  });
 
   this.proxy_server = http.createServer(
     log_errors(dynamicProxy.handleProxyRequest)
@@ -72,8 +72,8 @@ DynamicProxy.prototype.rewriteRequest = function(request) {
   }
 };
 
-DynamicProxy.prototype.targetFromSessionMap = function(request) {
-  for (var mappedSession in this.sessionMap) {
+DynamicProxy.prototype.targetFromSessionMap = function(key, token) {
+  for (let mappedSession in this.sessionMap) {
     if (key == mappedSession) {
       if (this.sessionMap[key].token == token) {
         return this.sessionMap[key].target;
@@ -91,14 +91,18 @@ DynamicProxy.prototype.targetFromHeaders = function(request) {
 
 DynamicProxy.prototype.targetForRequest = function(request) {
   // return proxy target for a given url
-  req_host = request.headers.host;
-  key = req_host.substring(0, req_host.indexOf("-"));
-  token = req_host.substring(req_host.indexOf("-") + 1, req_host.indexOf("."));
+  const req_host = request.headers.host;
+  const key = req_host.substring(0, req_host.indexOf("-"));
+  const token = req_host.substring(
+    req_host.indexOf("-") + 1,
+    req_host.indexOf(".")
+  );
 
+  let target;
   if (this.sessionMap) {
-    var target = this.targetFromSessionMap(request);
+    target = this.targetFromSessionMap(key, token);
   } else {
-    var target = this.targetFromHeaders(request);
+    target = this.targetFromHeaders(request);
   }
 
   if (target) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,213 +1,265 @@
-var http = require('http'),
-    httpProxy = require('http-proxy');
+var http = require("http"),
+  httpProxy = require("http-proxy");
 
-var bound = function (that, method) {
-    // bind a method, to ensure `this=that` when it is called
-    // because prototype languages are bad
-    return function () {
-        method.apply(that, arguments);
-    };
+var bound = function(that, method) {
+  // bind a method, to ensure `this=that` when it is called
+  // because prototype languages are bad
+  return function() {
+    method.apply(that, arguments);
+  };
 };
 
 var DynamicProxy = function(options) {
-    var dynamicProxy = this;
-    this.sessionCookie = options.sessionCookie;
-    this.sessionMap = options.sessionMap;
-    this.debug = options.verbose;
-    this.reverseProxy = options.reverseProxy;
-    this.port = options.port;
-    this.forwardIP = options.forwardIP;
-    this.forwardPort = options.forwardPort;
+  var dynamicProxy = this;
+  this.sessionCookie = options.sessionCookie;
+  this.sessionMap = options.sessionMap;
+  this.debug = options.verbose;
+  this.reverseProxy = options.reverseProxy;
+  this.port = options.port;
+  this.forwardIP = options.forwardIP;
+  this.forwardPort = options.forwardPort;
 
-    var log_errors = function(handler) {
-        return function (req, res) {
-            try {
-                return handler.apply(dynamicProxy, arguments);
-            } catch (e) {
-                console.log("Error in handler for " + req.headers.host + " " + req.method + ' ' + req.url + ': ', e);
-            }
-        };
+  var log_errors = function(handler) {
+    return function(req, res) {
+      try {
+        return handler.apply(dynamicProxy, arguments);
+      } catch (e) {
+        console.log(
+          "Error in handler for " +
+            req.headers.host +
+            " " +
+            req.method +
+            " " +
+            req.url +
+            ": ",
+          e
+        );
+      }
     };
+  };
 
-    var proxy = this.proxy = httpProxy.createProxyServer({
-        ws : true,
-    });
+  var proxy = (this.proxy = httpProxy.createProxyServer({
+    ws: true
+  }));
 
-    this.proxy_server = http.createServer(
-        log_errors(dynamicProxy.handleProxyRequest)
-    );
-    this.proxy_server.on('upgrade', bound(this, this.handleWs));
+  this.proxy_server = http.createServer(
+    log_errors(dynamicProxy.handleProxyRequest)
+  );
+  this.proxy_server.on("upgrade", bound(this, this.handleWs));
 };
 
 DynamicProxy.prototype.rewriteRequest = function(request) {
-    if(request.url.indexOf('rstudio') != -1){
-        var remap = {
-            'content-type': 'Content-Type',
-            'content-length': 'Content-Length',
-        }
-        // RStudio isn't spec compliant and pitches a fit on NodeJS's http module's lowercase HTTP headers
-        for(var i = 0; i<Object.keys(remap).length; i++){
-            var key = Object.keys(remap)[i];
-            if(key in request.headers){
-                request.headers[remap[key]] = request.headers[key];
-                delete request.headers[key];
-            }
-        }
-        if('Content-Type' in request.headers && request.headers['Content-Type'] == 'application/x-www-form-urlencoded; charset=UTF-8'){
-            request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-        }
+  if (request.url.indexOf("rstudio") != -1) {
+    var remap = {
+      "content-type": "Content-Type",
+      "content-length": "Content-Length"
+    };
+    // RStudio isn't spec compliant and pitches a fit on NodeJS's http module's lowercase HTTP headers
+    for (var i = 0; i < Object.keys(remap).length; i++) {
+      var key = Object.keys(remap)[i];
+      if (key in request.headers) {
+        request.headers[remap[key]] = request.headers[key];
+        delete request.headers[key];
+      }
     }
-}
-
-DynamicProxy.prototype.targetFromSessionMap = function(request) {
-    for (var mappedSession in this.sessionMap) {
-        if(key == mappedSession) {
-            if(this.sessionMap[key].token == token){
-                return this.sessionMap[key].target;
-            }
-        }
+    if (
+      "Content-Type" in request.headers &&
+      request.headers["Content-Type"] ==
+        "application/x-www-form-urlencoded; charset=UTF-8"
+    ) {
+      request.headers["Content-Type"] = "application/x-www-form-urlencoded";
     }
-}
-
-DynamicProxy.prototype.targetFromHeaders = function(request) {
-    return {'host': request.headers['x-interactive-tool-host'], 'port': parseInt(request.headers['x-interactive-tool-port'])};
-}
-
-DynamicProxy.prototype.targetForRequest = function(request) {
-    // return proxy target for a given url
-    req_host = request.headers.host;
-    key = req_host.substring(0, req_host.indexOf('-'));
-    token = req_host.substring(req_host.indexOf('-') + 1, req_host.indexOf('.'));
-
-    if(this.sessionMap) {
-        var target = this.targetFromSessionMap(request);
-    } else {
-        var target = this.targetFromHeaders(request);
-    }
-
-    if(target) {
-        return target;
-    }
-
-    if(this.debug) {
-        console.log("No target found for " + req_host + " " + request.method + " " + request.url)
-    }
-    return null;
+  }
 };
 
+DynamicProxy.prototype.targetFromSessionMap = function(request) {
+  for (var mappedSession in this.sessionMap) {
+    if (key == mappedSession) {
+      if (this.sessionMap[key].token == token) {
+        return this.sessionMap[key].target;
+      }
+    }
+  }
+};
+
+DynamicProxy.prototype.targetFromHeaders = function(request) {
+  return {
+    host: request.headers["x-interactive-tool-host"],
+    port: parseInt(request.headers["x-interactive-tool-port"])
+  };
+};
+
+DynamicProxy.prototype.targetForRequest = function(request) {
+  // return proxy target for a given url
+  req_host = request.headers.host;
+  key = req_host.substring(0, req_host.indexOf("-"));
+  token = req_host.substring(req_host.indexOf("-") + 1, req_host.indexOf("."));
+
+  if (this.sessionMap) {
+    var target = this.targetFromSessionMap(request);
+  } else {
+    var target = this.targetFromHeaders(request);
+  }
+
+  if (target) {
+    return target;
+  }
+
+  if (this.debug) {
+    console.log(
+      "No target found for " +
+        req_host +
+        " " +
+        request.method +
+        " " +
+        request.url
+    );
+  }
+  return null;
+};
 
 DynamicProxy.prototype.configureForward = function(req, target) {
-    var _target = Object.assign({}, target);
-    if(this.forwardIP) {
-        console.log("Forwarding request for " + target.host + " to " + this.forwardIP);
-        req.headers['x-interactive-tool-host'] = target.host;
-        _target.host = this.forwardIP;
-    } else {
-        delete req.headers['x-interactive-tool-host'];
-    }
-    if(this.forwardPort) {
-        console.log("Forwarding request for " + target.port + " to " + this.forwardPort);
-        req.headers['x-interactive-tool-port'] = target.port;
-        _target.port = this.forwardPort;
-    } else {
-        delete req.headers['x-interactive-tool-port'];
-    }
-    return _target
-}
+  var _target = Object.assign({}, target);
+  if (this.forwardIP) {
+    console.log(
+      "Forwarding request for " + target.host + " to " + this.forwardIP
+    );
+    req.headers["x-interactive-tool-host"] = target.host;
+    _target.host = this.forwardIP;
+  } else {
+    delete req.headers["x-interactive-tool-host"];
+  }
+  if (this.forwardPort) {
+    console.log(
+      "Forwarding request for " + target.port + " to " + this.forwardPort
+    );
+    req.headers["x-interactive-tool-port"] = target.port;
+    _target.port = this.forwardPort;
+  } else {
+    delete req.headers["x-interactive-tool-port"];
+  }
+  return _target;
+};
 
 DynamicProxy.prototype.handleProxyRequest = function(req, res) {
-    var othis = this;
-    var target = this.targetForRequest(req);
-    if(this.debug && target) {
-        console.log("PROXY " + req.headers.host + " " + req.method + " " + req.url + " to " + target.host + ':' + target.port);
+  var othis = this;
+  var target = this.targetForRequest(req);
+  if (this.debug && target) {
+    console.log(
+      "PROXY " +
+        req.headers.host +
+        " " +
+        req.method +
+        " " +
+        req.url +
+        " to " +
+        target.host +
+        ":" +
+        target.port
+    );
+  }
+  var origin = req.headers.origin;
+  this.rewriteRequest(req);
+  res.oldWriteHead = res.writeHead;
+
+  res.writeHead = function(statusCode, headers) {
+    if (othis.reverseProxy && statusCode === 302) {
+      if (res && res._headers) {
+        if (othis.debug) {
+          console.log("Original Location Header: " + res._headers.location);
+        }
+        if (res._headers.location) {
+          res._headers.location = res._headers.location.replace(
+            "http://localhost/",
+            "http://localhost:" + othis.port + "/"
+          );
+        }
+        if (othis.debug) {
+          console.log("Rewritten Location Header: " + res._headers.location);
+        }
+      }
     }
-    var origin = req.headers.origin;
-    this.rewriteRequest(req);
-    res.oldWriteHead = res.writeHead;
+    try {
+      if (origin) {
+        res.setHeader("Access-Control-Allow-Origin", origin);
+      }
+      res.setHeader("Access-Control-Allow-Credentials", "true");
 
-    res.writeHead = function(statusCode, headers) {
-        if(othis.reverseProxy && statusCode === 302){
-            if(res && res._headers){
-                if(othis.debug){
-                    console.log("Original Location Header: " + res._headers.location);
-                }
-                if(res._headers.location){
-                    res._headers.location = res._headers.location.replace('http://localhost/', 'http://localhost:' + othis.port + '/');
-                }
-                if(othis.debug){
-                    console.log("Rewritten Location Header: " + res._headers.location);
-                }
-            }
-        }
-        try {
-            if(origin){
-                res.setHeader('Access-Control-Allow-Origin', origin);
-            }
-            res.setHeader('Access-Control-Allow-Credentials', 'true');
-
-            if(!headers){
-                headers = {};
-            }
-            res.oldWriteHead(statusCode, headers);
-        }
-        catch (error) {
-          console.log("Header could not be modified.");
-          console.log(error);
-        }
-
+      if (!headers) {
+        headers = {};
+      }
+      res.oldWriteHead(statusCode, headers);
+    } catch (error) {
+      console.log("Header could not be modified.");
+      console.log(error);
     }
-    target = this.configureForward(req, target);
-    this.proxy.web(req, res, {
-        target: target
-    }, function (e) {
-        console.log("Proxy error: ", e);
-        res.writeHead(502);
-        res.write("Proxy target missing");
-        res.end();
-    });
+  };
+  target = this.configureForward(req, target);
+  this.proxy.web(
+    req,
+    res,
+    {
+      target: target
+    },
+    function(e) {
+      console.log("Proxy error: ", e);
+      res.writeHead(502);
+      res.write("Proxy target missing");
+      res.end();
+    }
+  );
 };
 
 DynamicProxy.prototype.handleWs = function(req, res, head) {
-    // no local route found, time to proxy
-    var target = this.targetForRequest(req);
-    if(this.debug && target) {
-        console.log("PROXY WS " + req.url + " to " + target.host + ':' + target.port);
+  // no local route found, time to proxy
+  var target = this.targetForRequest(req);
+  if (this.debug && target) {
+    console.log(
+      "PROXY WS " + req.url + " to " + target.host + ":" + target.port
+    );
+  }
+  var origin = req.headers.origin;
+  this.rewriteRequest(req);
+  res.oldWriteHead = res.writeHead;
+  res.writeHead = function(statusCode, headers) {
+    try {
+      if (origin) {
+        res.setHeader("Access-Control-Allow-Origin", origin);
+      }
+      res.setHeader("Access-Control-Allow-Credentials", "true");
+      if (!headers) {
+        headers = {};
+      }
+      res.oldWriteHead(statusCode, headers);
+    } catch (error) {
+      console.log("Header could not be modified.");
+      console.log(error);
     }
-    var origin = req.headers.origin;
-    this.rewriteRequest(req);
-    res.oldWriteHead = res.writeHead;
-    res.writeHead = function(statusCode, headers) {
-        try {
-            if(origin){
-                res.setHeader('Access-Control-Allow-Origin', origin);
-            }
-            res.setHeader('Access-Control-Allow-Credentials', 'true');
-            if(!headers){ headers = {}; }
-            res.oldWriteHead(statusCode, headers);
-        }
-        catch (error) {
-          console.log("Header could not be modified.");
-          console.log(error);
-        }
+  };
+  this.proxy.ws(
+    req,
+    res,
+    head,
+    {
+      target: target
+    },
+    function(e) {
+      console.log("Proxy error: ", e);
+      res.writeHead(502);
+      res.write("Proxy target missing");
+      res.end();
     }
-    this.proxy.ws(req, res, head, {
-        target: target
-    }, function (e) {
-        console.log("Proxy error: ", e);
-        res.writeHead(502);
-        res.write("Proxy target missing");
-        res.end();
-    });
+  );
 };
 
 DynamicProxy.prototype.listen = function(args_) {
-    const args = args_ || {};
-    const port = this.port || 8000;
-    const ip = args.ip || 'localhost';
-    if(this.debug) {
-	    console.log("Listening on " + ip + ":" + port);
-    }
-    this.proxy_server.listen(port, ip);
-}
+  const args = args_ || {};
+  const port = this.port || 8000;
+  const ip = args.ip || "localhost";
+  if (this.debug) {
+    console.log("Listening on " + ip + ":" + port);
+  }
+  this.proxy_server.listen(port, ip);
+};
 
 exports.DynamicProxy = DynamicProxy;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -71,13 +71,16 @@ DynamicProxy.prototype.targetForRequest = function(request) {
         }
     }
 
+    if(this.debug) {
+        console.log("No target found for " + req_host + " " + req.method + " " + req.url)
+    }
     return null;
 };
 
 DynamicProxy.prototype.handleProxyRequest = function(req, res) {
     var othis = this;
     var target = this.targetForRequest(req);
-    if(this.debug) {
+    if(this.debug && target) {
         console.log("PROXY " + req.headers.host + " " + req.method + " " + req.url + " to " + target.host + ':' + target.port);
     }
     var origin = req.headers.origin;
@@ -128,7 +131,7 @@ DynamicProxy.prototype.handleProxyRequest = function(req, res) {
 DynamicProxy.prototype.handleWs = function(req, res, head) {
     // no local route found, time to proxy
     var target = this.targetForRequest(req);
-    if(this.debug) {
+    if(this.debug && target) {
         console.log("PROXY WS " + req.url + " to " + target.host + ':' + target.port);
     }
     var origin = req.headers.origin;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -59,29 +59,15 @@ DynamicProxy.prototype.rewriteRequest = function(request) {
 
 DynamicProxy.prototype.targetForRequest = function(request) {
     // return proxy target for a given url
-    var session = this.findSession(request);
+    req_host = request.headers.host;
+    key = req_host.substring(0, req_host.indexOf('-'));
+    token = req_host.substring(req_host.indexOf('-') + 1, req_host.indexOf('.'));
+
     for (var mappedSession in this.sessionMap) {
-        if(session == mappedSession) {
-            return this.sessionMap[session].target;
-        }
-    }
-
-    return null;
-};
-
-DynamicProxy.prototype.findSession = function(request) {
-    var sessionCookie = this.sessionCookie,
-        rc = request.headers.cookie;
-    if(!rc) {
-        return null;
-    }
-    var cookies = rc.split(';');
-    for(var cookieIndex in cookies) {
-        var cookie = cookies[cookieIndex];
-        var parts = cookie.split('=');
-        var partName = parts.shift().trim();
-        if(partName == sessionCookie) {
-            return unescape(parts.join('='))
+        if(key == mappedSession) {
+		if(this.sessionMap[key].token == token){
+            		return this.sessionMap[key].target;
+		}
         }
     }
 
@@ -92,7 +78,7 @@ DynamicProxy.prototype.handleProxyRequest = function(req, res) {
     var othis = this;
     var target = this.targetForRequest(req);
     if(this.debug) {
-        console.log("PROXY " + req.method + " " + req.url + " to " + target.host + ':' + target.port);
+        console.log("PROXY " + req.headers.host + " " + req.method + " " + req.url + " to " + target.host + ':' + target.port);
     }
     var origin = req.headers.origin;
     this.rewriteRequest(req);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -98,16 +98,19 @@ DynamicProxy.prototype.targetForRequest = function(request) {
 
 DynamicProxy.prototype.configureForward = function(req, target) {
     var _target = Object.assign({}, target);
-    // FIXME: else delete header so the proxy can't be controlled
     if(this.forwardIP) {
         console.log("Forwarding request for " + target.host + " to " + this.forwardIP);
         req.headers['x-interactive-tool-host'] = target.host;
         _target.host = this.forwardIP;
+    } else {
+        delete req.headers['x-interactive-tool-host'];
     }
     if(this.forwardPort) {
         console.log("Forwarding request for " + target.port + " to " + this.forwardPort);
         req.headers['x-interactive-tool-port'] = target.port;
         _target.port = this.forwardPort;
+    } else {
+        delete req.headers['x-interactive-tool-port'];
     }
     return _target
 }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -22,7 +22,7 @@ var DynamicProxy = function(options) {
             try {
                 return handler.apply(dynamicProxy, arguments);
             } catch (e) {
-                console.log("Error in handler for " + req.method + ' ' + req.url + ': ', e);
+                console.log("Error in handler for " + req.headers.host + " " + req.method + ' ' + req.url + ': ', e);
             }
         };
     };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -200,4 +200,14 @@ DynamicProxy.prototype.handleWs = function(req, res, head) {
     });
 };
 
+DynamicProxy.prototype.listen = function(args_) {
+    const args = args_ || {};
+    const port = this.port || 8000;
+    const ip = args.ip || 'localhost';
+    if(this.debug) {
+	    console.log("Listening on " + ip + ":" + port);
+    }
+    this.proxy_server.listen(port, ip);
+}
+
 exports.DynamicProxy = DynamicProxy;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -266,4 +266,9 @@ DynamicProxy.prototype.listen = function(args_) {
   this.proxy_server.listen(port, ip);
 };
 
+DynamicProxy.prototype.close = function() {
+  this.proxy.close();
+  this.proxy_server.close();
+};
+
 exports.DynamicProxy = DynamicProxy;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "galaxy-proxy",
-  "version": "0.0.2",
-  "description": "A dynamic reverse proxy for use within Galaxy",
-  "main": "index.js",
+  "name": "gx-it-proxy",
+  "version": "0.0.3",
+  "description": "A dynamic reverse proxy for Interactive Tools in Galaxy",
+  "main": "lib/main.js",
+  "bin": { "gx-it-proxy": "lib/main.js" },
+  "keywords": [
+    "galaxy",
+    "proxy"
+  ],
   "author": "Galaxy Project",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "sqlite3": "4.0.4"
   },
   "devDependencies": {
-    "mocha": "*",
-    "chai": "*",
     "axios": "*",
-    "axios-retry": "*"
+    "axios-retry": "*",
+    "chai": "*",
+    "mocha": "*",
+    "prettier": "1.19.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "mocha --reporter spec",
     "lint": "eslint lib test",
-    "format": "prettier --write lib/*js test/*js"
+    "format": "prettier --write lib/*js test/*js",
+    "format-check": "prettier --check lib/*js test/*js"
   },
   "dependencies": {
     "commander": "~2.19.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "url": "git://github.com/usegalaxy-eu/gie-nodejs-proxy"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "test": "mocha --reporter spec",
+    "lint": "eslint lib test",
+    "format": "prettier --write lib/*js test/*js"
   },
   "dependencies": {
     "commander": "~2.19.0",
@@ -24,6 +26,8 @@
     "axios": "*",
     "axios-retry": "*",
     "chai": "*",
+    "eslint": "^6.8.0",
+    "eslint-config-strongloop": "^2.1.0",
     "mocha": "*",
     "prettier": "1.19.1"
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git://github.com/usegalaxy-eu/gie-nodejs-proxy"
   },
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
   "dependencies": {
     "commander": "~2.19.0",
     "eventemitter3": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "galaxy-proxy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A dynamic reverse proxy for use within Galaxy",
   "main": "index.js",
-  "author": "John Chilton",
-  "license": "AFL-3.0",
+  "author": "Galaxy Project",
+  "license": "MIT",
   "readmeFilename": "README.md",
   "repository": {
-    "type": "mercurial",
-    "url": "https://bitbucket.org/galaxy/galaxy-central"
+    "type": "git",
+    "url": "git://github.com/usegalaxy-eu/gie-nodejs-proxy"
   },
   "dependencies": {
     "commander": "~2.19.0",
@@ -16,5 +16,8 @@
     "http-proxy": "1.17.0",
     "node-watch": "0.6.2",
     "sqlite3": "4.0.4"
+  },
+  "devDependencies": {
+    "mocha": "2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "sqlite3": "4.0.4"
   },
   "devDependencies": {
-    "mocha": "2"
+    "mocha": "*",
+    "chai": "*",
+    "axios": "*",
+    "axios-retry": "*"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,8 @@
-var main = require("../lib/main");
-var { DynamicProxy } = require("../lib/proxy");
-var http = require("http");
-var url = require("url");
-var path = require("path");
-var fs = require("fs");
+const { DynamicProxy } = require("../lib/proxy");
+const http = require("http");
+const url = require("url");
+const path = require("path");
+const fs = require("fs");
 require("chai").should();
 const axios = require("axios");
 const axiosRetry = require("axios-retry");
@@ -66,14 +65,14 @@ const testServer = http.createServer(function(req, res) {
   });
 });
 
-async function waitForServer(server, listening) {
-  while (true) {
+const waitForServer = async function(server, listening) {
+  for (;;) {
     if (server.listening == listening) {
       return;
     }
     await null; // prevents app from hanging
   }
-}
+};
 
 const useTestServer = function() {
   before(async function() {
@@ -104,7 +103,7 @@ describe("DynamicProxy", function() {
       proxy.listen();
       // This never becomes True for the proxy server... why?
       // await waitForServer(proxy.proxy, true);
-      headers = {
+      const headers = {
         "x-interactive-tool-host": "localhost",
         "x-interactive-tool-port": TEST_PORT
       };
@@ -133,7 +132,7 @@ describe("DynamicProxy", function() {
         sessionMap: sessionMap
       });
       proxy.listen();
-      headers = {
+      const headers = {
         host: "coolkey-cooltoken.usegalaxy.org"
       };
       let res = await axios.get(`http://localhost:5099/README.md`, {
@@ -165,7 +164,7 @@ describe("DynamicProxy", function() {
       const innerProxy = new DynamicProxy({ port: 5101, verbose: true });
       outerProxy.listen();
       innerProxy.listen();
-      headers = {
+      const headers = {
         host: "coolkey-cooltoken.usegalaxy.org"
       };
       let res = await axios.get(`http://localhost:5100/README.md`, {

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,12 @@
-var main = require('../lib/main');
-var { DynamicProxy } = require('../lib/proxy');
-var http = require('http');
-var url = require('url');
-var path = require('path');
-var fs = require('fs');
-require('chai').should();
-const axios = require('axios');
-const axiosRetry = require('axios-retry');
+var main = require("../lib/main");
+var { DynamicProxy } = require("../lib/proxy");
+var http = require("http");
+var url = require("url");
+var path = require("path");
+var fs = require("fs");
+require("chai").should();
+const axios = require("axios");
+const axiosRetry = require("axios-retry");
 
 // Needed because I can't figure out how to wait on the proxy server to get
 // setup (server.listening stays false forever). This greatly reduces transient
@@ -16,8 +16,8 @@ axiosRetry(axios, { retries: 3 });
 const TEST_PORT = 9000;
 
 // Loosely based on https://stackoverflow.com/questions/16333790/node-js-quick-file-server-static-files-over-http
-const testServer = http.createServer(function (req, res) {
-    console.log(`${req.method} ${req.url}`);
+const testServer = http.createServer(function(req, res) {
+  console.log(`${req.method} ${req.url}`);
 
   // parse URL
   const parsedUrl = url.parse(req.url);
@@ -27,22 +27,22 @@ const testServer = http.createServer(function (req, res) {
   const ext = path.parse(pathname).ext;
   // maps file extension to MIME type
   const map = {
-    '.ico': 'image/x-icon',
-    '.html': 'text/html',
-    '.js': 'text/javascript',
-    '.json': 'application/json',
-    '.css': 'text/css',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.wav': 'audio/wav',
-    '.mp3': 'audio/mpeg',
-    '.svg': 'image/svg+xml',
-    '.pdf': 'application/pdf',
-    '.doc': 'application/msword'
+    ".ico": "image/x-icon",
+    ".html": "text/html",
+    ".js": "text/javascript",
+    ".json": "application/json",
+    ".css": "text/css",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".svg": "image/svg+xml",
+    ".pdf": "application/pdf",
+    ".doc": "application/msword"
   };
 
-  fs.exists(pathname, function (exist) {
-    if(!exist) {
+  fs.exists(pathname, function(exist) {
+    if (!exist) {
       // if the file is not found, return 404
       res.statusCode = 404;
       res.end(`File ${pathname} not found!`);
@@ -50,114 +50,129 @@ const testServer = http.createServer(function (req, res) {
     }
 
     // if is a directory search for index file matching the extention
-    if (fs.statSync(pathname).isDirectory()) pathname += '/index' + ext;
+    if (fs.statSync(pathname).isDirectory()) pathname += "/index" + ext;
 
     // read file from file system
-    fs.readFile(pathname, function(err, data){
-      if(err){
+    fs.readFile(pathname, function(err, data) {
+      if (err) {
         res.statusCode = 500;
         res.end(`Error getting the file: ${err}.`);
       } else {
         // if the file is found, set Content-type and send data
-        res.setHeader('Content-type', map[ext] || 'text/plain' );
+        res.setHeader("Content-type", map[ext] || "text/plain");
         res.end(data);
       }
     });
   });
-
-
 });
 
 async function waitForServer(server, listening) {
-    while (true){
-        if (server.listening == listening) { return };
-        await null; // prevents app from hanging
+  while (true) {
+    if (server.listening == listening) {
+      return;
     }
+    await null; // prevents app from hanging
+  }
 }
 
 const useTestServer = function() {
-    before(async function() {
-        testServer.listen(TEST_PORT);
-        await waitForServer(testServer, true);
-    });
-    after(async function() {
-        testServer.close();
-        await waitForServer(testServer, false);
-    });
+  before(async function() {
+    testServer.listen(TEST_PORT);
+    await waitForServer(testServer, true);
+  });
+  after(async function() {
+    testServer.close();
+    await waitForServer(testServer, false);
+  });
 };
 
-describe('test server', function() {
-    useTestServer();
-    it('should serve direct requests as files', async function() {
-        let res = await axios.get(`http://localhost:${TEST_PORT}/README.md`);
-        let { data } = res;
-        console.log(data);
-        data.should.include('# A dynamic configurable reverse proxy');
-    });
+describe("test server", function() {
+  useTestServer();
+  it("should serve direct requests as files", async function() {
+    let res = await axios.get(`http://localhost:${TEST_PORT}/README.md`);
+    let { data } = res;
+    console.log(data);
+    data.should.include("# A dynamic configurable reverse proxy");
+  });
 });
 
-describe('DynamicProxy', function() {
-    useTestServer();
-    describe('x-interactive-tool-* headers', function() {
-        it('should respect host and port', async function() {
-            const proxy = new DynamicProxy({port: 5098, verbose: true});
-            proxy.listen();
-            // This never becomes True for the proxy server... why?
-            // await waitForServer(proxy.proxy, true);
-            headers = {
-                'x-interactive-tool-host': 'localhost',
-                'x-interactive-tool-port': TEST_PORT
-            }
-            let res = await axios.get(`http://localhost:5098/README.md`, { headers: headers});
-            let { data } = res;
-            data.should.include('# A dynamic configurable reverse proxy');
-        });
+describe("DynamicProxy", function() {
+  useTestServer();
+  describe("x-interactive-tool-* headers", function() {
+    it("should respect host and port", async function() {
+      const proxy = new DynamicProxy({ port: 5098, verbose: true });
+      proxy.listen();
+      // This never becomes True for the proxy server... why?
+      // await waitForServer(proxy.proxy, true);
+      headers = {
+        "x-interactive-tool-host": "localhost",
+        "x-interactive-tool-port": TEST_PORT
+      };
+      let res = await axios.get(`http://localhost:5098/README.md`, {
+        headers: headers
+      });
+      let { data } = res;
+      data.should.include("# A dynamic configurable reverse proxy");
     });
+  });
 
-    describe('map based forwarding', function() {
-        it('should respect session map', async function() {
-            const sessionMap = {
-                'coolkey': {
-                    'token': 'cooltoken',
-                    'target': {
-                        'host': 'localhost',
-                        'port': TEST_PORT
-                    }
-                }
-            };
-            const proxy = new DynamicProxy({port: 5099, verbose: true, sessionMap: sessionMap});
-            proxy.listen();
-            headers = {
-                'host': 'coolkey-cooltoken.usegalaxy.org'
-            }
-            let res = await axios.get(`http://localhost:5099/README.md`, { headers: headers});
-            let { data } = res;
-            data.should.include('# A dynamic configurable reverse proxy');
-        });
+  describe("map based forwarding", function() {
+    it("should respect session map", async function() {
+      const sessionMap = {
+        coolkey: {
+          token: "cooltoken",
+          target: {
+            host: "localhost",
+            port: TEST_PORT
+          }
+        }
+      };
+      const proxy = new DynamicProxy({
+        port: 5099,
+        verbose: true,
+        sessionMap: sessionMap
+      });
+      proxy.listen();
+      headers = {
+        host: "coolkey-cooltoken.usegalaxy.org"
+      };
+      let res = await axios.get(`http://localhost:5099/README.md`, {
+        headers: headers
+      });
+      let { data } = res;
+      data.should.include("# A dynamic configurable reverse proxy");
     });
+  });
 
-    describe('double proxying', function() {
-        it('should proxy across two servers', async function() {
-            const sessionMap = {
-                'coolkey': {
-                    'token': 'cooltoken',
-                    'target': {
-                        'host': 'localhost',
-                        'port': TEST_PORT
-                    }
-                }
-            };
-            const outerProxy = new DynamicProxy({port: 5100, verbose: true, sessionMap: sessionMap, forwardIP: 'localhost', forwardPort: 5101});
-            const innerProxy = new DynamicProxy({port: 5101, verbose: true});
-            outerProxy.listen();
-            innerProxy.listen();
-            headers = {
-                'host': 'coolkey-cooltoken.usegalaxy.org'
-            }
-            let res = await axios.get(`http://localhost:5100/README.md`, { headers: headers});
-            let { data } = res;
-            data.should.include('# A dynamic configurable reverse proxy');
-        });
+  describe("double proxying", function() {
+    it("should proxy across two servers", async function() {
+      const sessionMap = {
+        coolkey: {
+          token: "cooltoken",
+          target: {
+            host: "localhost",
+            port: TEST_PORT
+          }
+        }
+      };
+      const outerProxy = new DynamicProxy({
+        port: 5100,
+        verbose: true,
+        sessionMap: sessionMap,
+        forwardIP: "localhost",
+        forwardPort: 5101
+      });
+      const innerProxy = new DynamicProxy({ port: 5101, verbose: true });
+      outerProxy.listen();
+      innerProxy.listen();
+      headers = {
+        host: "coolkey-cooltoken.usegalaxy.org"
+      };
+      let res = await axios.get(`http://localhost:5100/README.md`, {
+        headers: headers
+      });
+      let { data } = res;
+      data.should.include("# A dynamic configurable reverse proxy");
     });
-
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,163 @@
+var main = require('../lib/main');
+var { DynamicProxy } = require('../lib/proxy');
+var http = require('http');
+var url = require('url');
+var path = require('path');
+var fs = require('fs');
+require('chai').should();
+const axios = require('axios');
+const axiosRetry = require('axios-retry');
+
+// Needed because I can't figure out how to wait on the proxy server to get
+// setup (server.listening stays false forever). This greatly reduces transient
+// connection refused errors as a result.
+axiosRetry(axios, { retries: 3 });
+
+const TEST_PORT = 9000;
+
+// Loosely based on https://stackoverflow.com/questions/16333790/node-js-quick-file-server-static-files-over-http
+const testServer = http.createServer(function (req, res) {
+    console.log(`${req.method} ${req.url}`);
+
+  // parse URL
+  const parsedUrl = url.parse(req.url);
+  // extract URL path
+  let pathname = `.${parsedUrl.pathname}`;
+  // based on the URL path, extract the file extension. e.g. .js, .doc, ...
+  const ext = path.parse(pathname).ext;
+  // maps file extension to MIME type
+  const map = {
+    '.ico': 'image/x-icon',
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.css': 'text/css',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.wav': 'audio/wav',
+    '.mp3': 'audio/mpeg',
+    '.svg': 'image/svg+xml',
+    '.pdf': 'application/pdf',
+    '.doc': 'application/msword'
+  };
+
+  fs.exists(pathname, function (exist) {
+    if(!exist) {
+      // if the file is not found, return 404
+      res.statusCode = 404;
+      res.end(`File ${pathname} not found!`);
+      return;
+    }
+
+    // if is a directory search for index file matching the extention
+    if (fs.statSync(pathname).isDirectory()) pathname += '/index' + ext;
+
+    // read file from file system
+    fs.readFile(pathname, function(err, data){
+      if(err){
+        res.statusCode = 500;
+        res.end(`Error getting the file: ${err}.`);
+      } else {
+        // if the file is found, set Content-type and send data
+        res.setHeader('Content-type', map[ext] || 'text/plain' );
+        res.end(data);
+      }
+    });
+  });
+
+
+});
+
+async function waitForServer(server, listening) {
+    while (true){
+        if (server.listening == listening) { return };
+        await null; // prevents app from hanging
+    }
+}
+
+const useTestServer = function() {
+    before(async function() {
+        testServer.listen(TEST_PORT);
+        await waitForServer(testServer, true);
+    });
+    after(async function() {
+        testServer.close();
+        await waitForServer(testServer, false);
+    });
+};
+
+describe('test server', function() {
+    useTestServer();
+    it('should serve direct requests as files', async function() {
+        let res = await axios.get(`http://localhost:${TEST_PORT}/README.md`);
+        let { data } = res;
+        console.log(data);
+        data.should.include('# A dynamic configurable reverse proxy');
+    });
+});
+
+describe('DynamicProxy', function() {
+    useTestServer();
+    describe('x-interactive-tool-* headers', function() {
+        it('should respect host and port', async function() {
+            const proxy = new DynamicProxy({port: 5098, verbose: true});
+            proxy.listen();
+            // This never becomes True for the proxy server... why?
+            // await waitForServer(proxy.proxy, true);
+            headers = {
+                'x-interactive-tool-host': 'localhost',
+                'x-interactive-tool-port': TEST_PORT
+            }
+            let res = await axios.get(`http://localhost:5098/README.md`, { headers: headers});
+            let { data } = res;
+            data.should.include('# A dynamic configurable reverse proxy');
+        });
+    });
+
+    describe('map based forwarding', function() {
+        it('should respect session map', async function() {
+            const sessionMap = {
+                'coolkey': {
+                    'token': 'cooltoken',
+                    'target': {
+                        'host': 'localhost',
+                        'port': TEST_PORT
+                    }
+                }
+            };
+            const proxy = new DynamicProxy({port: 5099, verbose: true, sessionMap: sessionMap});
+            proxy.listen();
+            headers = {
+                'host': 'coolkey-cooltoken.usegalaxy.org'
+            }
+            let res = await axios.get(`http://localhost:5099/README.md`, { headers: headers});
+            let { data } = res;
+            data.should.include('# A dynamic configurable reverse proxy');
+        });
+    });
+
+    describe('double proxying', function() {
+        it('should proxy across two servers', async function() {
+            const sessionMap = {
+                'coolkey': {
+                    'token': 'cooltoken',
+                    'target': {
+                        'host': 'localhost',
+                        'port': TEST_PORT
+                    }
+                }
+            };
+            const outerProxy = new DynamicProxy({port: 5100, verbose: true, sessionMap: sessionMap, forwardIP: 'localhost', forwardPort: 5101});
+            const innerProxy = new DynamicProxy({port: 5101, verbose: true});
+            outerProxy.listen();
+            innerProxy.listen();
+            headers = {
+                'host': 'coolkey-cooltoken.usegalaxy.org'
+            }
+            let res = await axios.get(`http://localhost:5100/README.md`, { headers: headers});
+            let { data } = res;
+            data.should.include('# A dynamic configurable reverse proxy');
+        });
+    });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -87,12 +87,12 @@ const useTestServer = function() {
 };
 
 const verifyProxyOnPort = async function(port, headers) {
-    let res = await axios.get(`http://localhost:${port}/README.md`, {
-        headers: headers
-    });
-    let { data } = res;
-    data.should.include("# A dynamic configurable reverse proxy");
-}
+  let res = await axios.get(`http://localhost:${port}/README.md`, {
+    headers: headers
+  });
+  let { data } = res;
+  data.should.include("# A dynamic configurable reverse proxy");
+};
 
 describe("test server", function() {
   useTestServer();
@@ -179,8 +179,8 @@ describe("Main function", function() {
   it("should parse simple arguments and start proxy", async function() {
     const proxy = main(["nodejs", "coolproxy", "--port", "5200", "--verbose"]);
     const headers = {
-        "x-interactive-tool-host": "localhost",
-        "x-interactive-tool-port": TEST_PORT
+      "x-interactive-tool-host": "localhost",
+      "x-interactive-tool-port": TEST_PORT
     };
     await verifyProxyOnPort(5200, headers);
     proxy.close();


### PR DESCRIPTION
- IT work from @hexylena 
- Double proxy from @natefoo 
- Test cases for both of these.
- Improved package structure - aiming for a release to npm.
- Use a main function instead of a script, for more robust testing.
- Use prettier on the codebase. 

Should we just keep this codebase as is for GIEs and create a galaxyproject/gxit-nodejs-proxy repo for the IT version of this project?

Is everyone on board for publishing this properly as a package instead of remerging it into the Galaxy codebase?

It would only be a couple hours to update this to support GIEs and GxITs but @natefoo and I decided that was maybe not worth the effort.