### PR TITLE
Run npm audit fix --force

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "eventemitter3": "3.1.0",
     "http-proxy": "1.18.1",
     "node-watch": "0.6.2",
-    "sqlite3": "4.0.4"
+    "sqlite3": "^4.2.0"
   },
   "devDependencies": {
     "axios": "*",
     "axios-retry": "*",
     "chai": "*",
-    "eslint": "^6.8.0",
+    "eslint": "^8.1.0",
     "eslint-config-strongloop": "^2.1.0",
     "mocha": "*",
     "prettier": "1.19.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eventemitter3": "3.1.0",
     "http-proxy": "1.18.1",
     "node-watch": "0.6.2",
-    "sqlite3": "^4.2.0"
+    "sqlite3": "5.0.2"
   },
   "devDependencies": {
     "axios": "*",


### PR DESCRIPTION
I couldn't install sqlite 4.0.4, the binary had disappeared and building
from source failed.

I have not yet tested if this works.