### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # Checking out the repo
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: galaxy/gx-it-proxy
         workdir: docker


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore