### PR TITLE
Rename package to @galaxyproject/gx-it-proxy and update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ## Invoking
 
 This project can be invoked from ``lib/main.js`` script in the source or
-installed and invoked through its [published package](https://www.npmjs.com/package/gx-it-proxy) via npm or npx.
+installed and invoked through its [published package](https://www.npmjs.com/package/@galaxyproject/gx-it-proxy) via npm or npx.
 
 ```console
-$ npx gx-it-proxy --version
-$ npx gx-it-proxy --sessions test.sqlite --port 8001  # use SQLite
-$ npx gx-it-proxy --sessions test.json --port 8001    # use a JSON file
-$ npx gx-it-proxy --sessions postgresql:///galaxy?host=/var/run/postgresql --port 8001  # use PostgreSQL
+$ npx @galaxyproject/gx-it-proxy --version
+$ npx @galaxyproject/gx-it-proxy --sessions test.sqlite --port 8001  # use SQLite
+$ npx @galaxyproject/gx-it-proxy --sessions test.json --port 8001    # use a JSON file
+$ npx @galaxyproject/gx-it-proxy --sessions postgresql:///galaxy?host=/var/run/postgresql --port 8001  # use PostgreSQL
 ```
 
 ## Double Proxy

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gx-it-proxy",
+  "name": "@galaxyproject/gx-it-proxy",
   "version": "0.2.0",
   "description": "A dynamic reverse proxy for Interactive Tools in Galaxy",
   "main": "lib/main.js",
@@ -16,7 +16,7 @@
   "readmeFilename": "README.md",
   "repository": {
     "type": "git",
-    "url": "git://github.com/usegalaxy-eu/gie-nodejs-proxy"
+    "url": "git://github.com/galaxyproject/gx-it-proxy"
   },
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
Have not published this yet, but opening for discussion.  This shifts publication to the @galaxyproject namespace and associated permission groups.  Would require updating various external docs.