### PR TITLE
Publish under galaxy namespace (and fix merge).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gx-it-proxy",
+  "name": "@galaxyproject/gx-it-proxy",
   "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gx-it-proxy",
+      "name": "@galaxyproject/gx-it-proxy",
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
@@ -2226,6 +2226,7 @@
     },
     "node_modules/libpq": {
       "version": "1.8.13",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@galaxyproject/gx-it-proxy",
-  "name": "gx-it-proxy",
   "version": "0.2.1",
   "description": "A dynamic reverse proxy for Interactive Tools in Galaxy",
   "main": "lib/main.js",


### PR DESCRIPTION
Looks like there was a merge issue in the last branch we didn't notice.

Went ahead and published the change as it sits in this branch, available at `@galaxyproject/gx-it-proxy@0.2.1`